### PR TITLE
Drop blueprint compiler

### DIFF
--- a/io.missioncenter.MissionCenter.json
+++ b/io.missioncenter.MissionCenter.json
@@ -224,20 +224,6 @@
       ]
     },
     {
-      "name": "blueprint-compiler",
-      "buildsystem": "meson",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/GNOME/blueprint-compiler/archive/refs/tags/0.18.0.tar.gz",
-          "sha256": "51aa472ecd7bd4b32b8baa7ae6768b19810793d4a2a1aba39c5b31b0170cb258"
-        }
-      ],
-      "cleanup": [
-        "*"
-      ]
-    },
-    {
       "name": "missioncenter",
       "buildsystem": "meson",
       "builddir": true,


### PR DESCRIPTION
Blueprint compiler is now part of GNOME runtime 49.