### PR TITLE
Test: Use the libarchive module from the runtime

### DIFF
--- a/io.missioncenter.MissionCenter.json
+++ b/io.missioncenter.MissionCenter.json
@@ -344,25 +344,6 @@
               ],
               "modules": [
                 {
-                  "name": "libarchive",
-                  "buildsystem": "autotools",
-                  "config-opts": [
-                    "--disable-bsdcat",
-                    "--disable-bsdcpio",
-                    "--disable-bsdtar"
-                  ],
-                  "sources": [
-                    {
-                      "type": "archive",
-                      "url": "https://github.com/libarchive/libarchive/releases/download/v3.6.2/libarchive-3.6.2.tar.xz",
-                      "sha256": "9e2c1b80d5fbe59b61308fdfab6c79b5021d7ff4ff2489fb12daf0a96a83551d"
-                    }
-                  ],
-                  "cleanup": [
-                    "*"
-                  ]
-                },
-                {
                   "name": "libtalloc",
                   "buildsystem": "autotools",
                   "sources": [


### PR DESCRIPTION
GNOME runtime version 49 (based on Freedesktop runtime version 25.08) provides the libarchive module.

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

Fixes: https://github.com/flathub/io.missioncenter.MissionCenter/issues/44